### PR TITLE
fix: Validation of personas

### DIFF
--- a/src/mongoModelsRepo/deletePersonaAttribute.ts
+++ b/src/mongoModelsRepo/deletePersonaAttribute.ts
@@ -9,7 +9,6 @@ import { PERSONA_ATTRIBUTES_COLLECTION } from './utils/constants/collections';
 export default (config: Config) => {
   return async ({id, organisation}: DeletePersonaAttributeOptions): Promise<void> => {
     const collection = (await config.db).collection(PERSONA_ATTRIBUTES_COLLECTION);
-
     const result = await collection.deleteOne({
       _id: new ObjectID(id),
       organisation: new ObjectID(organisation),

--- a/src/mongoModelsRepo/setIdentifierPersona.ts
+++ b/src/mongoModelsRepo/setIdentifierPersona.ts
@@ -3,6 +3,7 @@ import SetIdentifierPersonaOptions from '../repoFactory/options/SetIdentifierPer
 import SetIdentifierPersonaResult from '../repoFactory/results/SetIdentifierPersonaResult';
 import Config from './Config';
 import createOrUpdateIdentifier from './utils/createOrUpdateIdentifier';
+import getPersonaById from './utils/getPersonaById';
 
 export default (config: Config) => {
   return async ({
@@ -10,6 +11,8 @@ export default (config: Config) => {
     organisation,
     persona,
   }: SetIdentifierPersonaOptions): Promise<SetIdentifierPersonaResult> => {
+    // check persona exists
+    await getPersonaById(config)({ organisation, personaId: persona });
 
     const filter = {
       _id: new ObjectID(id),

--- a/src/mongoModelsRepo/updateIdentifier.ts
+++ b/src/mongoModelsRepo/updateIdentifier.ts
@@ -10,17 +10,17 @@ export default (config: Config) => {
     id,
     persona,
     organisation,
-    ifi,
   }: UpdateIdentifierOptions): Promise<UpdateIdentifierResult> => {
     const collection = (await config.db).collection(PERSONA_IDENTIFIERS_COLLECTION);
 
     const result = await collection.findOneAndUpdate({
       _id: new ObjectID(id),
       organisation: new ObjectID(organisation),
-    }, {
-      ifi,
-      organisation: new ObjectID(organisation),
-      persona,
+    },
+    {
+      $set: {
+        persona,
+      },
     }, {
       returnOriginal: false,
       upsert: false,

--- a/src/mongoModelsRepo/updatePersona.ts
+++ b/src/mongoModelsRepo/updatePersona.ts
@@ -22,10 +22,13 @@ export default (config: Config) => {
     const result = await collection.findOneAndUpdate({
       _id: new ObjectID(personaId),
       organisation: new ObjectID(organisation),
-    }, {
-      name,
-      organisation: new ObjectID(organisation),
-    }, {
+    },
+    {
+      $set: {
+        name,
+      },
+    },
+    {
       returnOriginal: false,
       upsert: false,
     });

--- a/src/serviceFactory/options/UpdateIdentifierOptions.ts
+++ b/src/serviceFactory/options/UpdateIdentifierOptions.ts
@@ -1,8 +1,5 @@
-import Ifi from '../../models/Ifi';
-
 interface UpdateIdentifierOptions {
   readonly id: string;
-  readonly ifi: Ifi;
   readonly persona?: string;
   readonly organisation: string;
 }

--- a/src/tests/deletePersonaAttribute/deletePersonaAttribute.test.ts
+++ b/src/tests/deletePersonaAttribute/deletePersonaAttribute.test.ts
@@ -9,7 +9,7 @@ import { TEST_ORGANISATION } from '../utils/values';
 describe('deletePersonaAttribute', () => {
   const service = setup();
 
-  it('Should delete persona identifier', async () => {
+  it('Should delete persona attribute', async () => {
     const { attribute } = await createTestAttribute();
 
     await service.deletePersonaAttribute({

--- a/src/tests/getPersonaAttributes/getPersonaAttributes.test.ts
+++ b/src/tests/getPersonaAttributes/getPersonaAttributes.test.ts
@@ -1,43 +1,44 @@
 // tslint:disable:no-magic-numbers
 // tslint:disable:max-file-line-count
 import * as assert from 'assert';
+import createTestPersona from '../utils/createTestPersona';
 import setup from '../utils/setup';
 import {
   TEST_ORGANISATION,
-  TEST_PERSONA_ID,
-  TEST_PERSONA_ID_2,
 } from '../utils/values';
 
 describe('getPersonaAttributes', () => {
-  const personaId = TEST_PERSONA_ID;
   const service = setup();
-  const attributeData1 = {
-    key: 'theKey',
-    organisation: TEST_ORGANISATION,
-    personaId,
-    value: 'theValue',
-  };
-  const attributeData2 = {
-    key: 'theKey2',
-    organisation: TEST_ORGANISATION,
-    personaId,
-    value: true,
-  };
-  const attributeData3 = {
-    key: 'theKey3',
-    organisation: TEST_ORGANISATION,
-    personaId: TEST_PERSONA_ID_2,
-    value: true,
-  };
 
   it('should get all persona attributes with default options', async () => {
+    const newPersona = await createTestPersona('Dave');
+    const newPersona2 = await createTestPersona('Dave 2');
+    const attributeData1 = {
+      key: 'theKey',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: 'theValue',
+    };
+    const attributeData2 = {
+      key: 'theKey2',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: true,
+    };
+    const attributeData3 = {
+      key: 'theKey3',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona2.id,
+      value: true,
+    };
+
     const { attribute: attribute1 } = await service.overwritePersonaAttribute(attributeData1);
     const { attribute: attribute2 } = await service.overwritePersonaAttribute(attributeData2);
     await service.overwritePersonaAttribute(attributeData3);
 
     const result = await service.getPersonaAttributes({
       organisation: TEST_ORGANISATION,
-      personaId,
+      personaId: newPersona.id,
     });
 
     assert.equal(result.attributes.length, 2); // tslint:disable-line:no-magic-numbers
@@ -47,6 +48,27 @@ describe('getPersonaAttributes', () => {
   });
 
   it('should get all persona attributes matching a filter', async () => {
+    const newPersona = await createTestPersona('Dave');
+    const newPersona2 = await createTestPersona('Dave 2');
+    const attributeData1 = {
+      key: 'theKey',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: 'theValue',
+    };
+    const attributeData2 = {
+      key: 'theKey2',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: true,
+    };
+    const attributeData3 = {
+      key: 'theKey3',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona2.id,
+      value: true,
+    };
+
     const { attribute: attribute1 } = await service.overwritePersonaAttribute(attributeData1);
     await service.overwritePersonaAttribute(attributeData2);
     await service.overwritePersonaAttribute(attributeData3);
@@ -62,6 +84,27 @@ describe('getPersonaAttributes', () => {
   });
 
   it('should get all persona attributes following the sort order', async () => {
+    const newPersona = await createTestPersona('Dave');
+    const newPersona2 = await createTestPersona('Dave 2');
+    const attributeData1 = {
+      key: 'theKey',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: 'theValue',
+    };
+    const attributeData2 = {
+      key: 'theKey2',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: true,
+    };
+    const attributeData3 = {
+      key: 'theKey3',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona2.id,
+      value: true,
+    };
+
     const { attribute: attribute1 } = await service.overwritePersonaAttribute(attributeData1);
     const { attribute: attribute2 } = await service.overwritePersonaAttribute(attributeData2);
     const { attribute: attribute3 } = await service.overwritePersonaAttribute(attributeData3);
@@ -79,6 +122,27 @@ describe('getPersonaAttributes', () => {
   });
 
   it('should get all persona attributes with a limit', async () => {
+    const newPersona = await createTestPersona('Dave');
+    const newPersona2 = await createTestPersona('Dave 2');
+    const attributeData1 = {
+      key: 'theKey',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: 'theValue',
+    };
+    const attributeData2 = {
+      key: 'theKey2',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: true,
+    };
+    const attributeData3 = {
+      key: 'theKey3',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona2.id,
+      value: true,
+    };
+
     await service.overwritePersonaAttribute(attributeData1);
     await service.overwritePersonaAttribute(attributeData2);
     await service.overwritePersonaAttribute(attributeData3);
@@ -92,6 +156,27 @@ describe('getPersonaAttributes', () => {
   });
 
   it('should get all persona attributes with a skip', async () => {
+    const newPersona = await createTestPersona('Dave');
+    const newPersona2 = await createTestPersona('Dave 2');
+    const attributeData1 = {
+      key: 'theKey',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: 'theValue',
+    };
+    const attributeData2 = {
+      key: 'theKey2',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona.id,
+      value: true,
+    };
+    const attributeData3 = {
+      key: 'theKey3',
+      organisation: TEST_ORGANISATION,
+      personaId: newPersona2.id,
+      value: true,
+    };
+
     await service.overwritePersonaAttribute(attributeData1);
     const { attribute: attribute2 } = await service.overwritePersonaAttribute(attributeData2);
     const { attribute: attribute3 } = await service.overwritePersonaAttribute(attributeData3);

--- a/src/tests/overwritePersonaAttribute/overwritePersonaAttribute.test.ts
+++ b/src/tests/overwritePersonaAttribute/overwritePersonaAttribute.test.ts
@@ -1,18 +1,19 @@
 import * as assert from 'assert';
+import createTestPersona from '../utils/createTestPersona';
 import setup from '../utils/setup';
 import {
   TEST_ORGANISATION,
 } from '../utils/values';
 
 describe('overwritePersonaAttribute', () => {
-  const personaId = '58fe13e34eabd3c26a7fc4c7';
   const service = setup();
 
   it('should create attribute', async () => {
+    const newPersona = await createTestPersona('Dave');
     const attribute1 = {
       key: 'theKey',
       organisation: TEST_ORGANISATION,
-      personaId,
+      personaId: newPersona.id,
       value: 'theValue',
     };
 
@@ -25,16 +26,17 @@ describe('overwritePersonaAttribute', () => {
   });
 
   it('should overwrite existing attribute', async () => {
+    const newPersona = await createTestPersona('Dave');
     const attribute1 = {
       key: 'theKey',
       organisation: TEST_ORGANISATION,
-      personaId,
+      personaId: newPersona.id,
       value: 'theValue1',
     };
     const attribute2 = {
       key: 'theKey',
       organisation: TEST_ORGANISATION,
-      personaId,
+      personaId: newPersona.id,
       value: 222,
     };
 
@@ -50,7 +52,7 @@ describe('overwritePersonaAttribute', () => {
 
     const result3 = await service.getPersonaAttributes({
       organisation: TEST_ORGANISATION,
-      personaId,
+      personaId: newPersona.id,
     });
 
     assert.deepEqual(result3.attributes[0], {

--- a/src/tests/setIdentifierPersona/setIdentifierPersona.test.ts
+++ b/src/tests/setIdentifierPersona/setIdentifierPersona.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import NoModel from 'jscommons/dist/errors/NoModel';
 import assertError from 'jscommons/dist/tests/utils/assertError';
+import NoModelWithId from '../../errors/NoModelWithId';
 import createTestIdentifier from '../utils/createTestIdentifier';
 import createTestPersona from '../utils/createTestPersona';
 import setup from '../utils/setup';
@@ -10,14 +11,27 @@ describe('setIdentifierPersona', () => {
   const service = setup();
 
   it('should NoModel error if no found identifier', async () => {
+    const newPersona = await createTestPersona('Dave');
 
     const resultPromise = service.setIdentifierPersona({
       id: '58fe13e34effd3c33a7fc4b8',
       organisation: TEST_ORGANISATION,
-      persona: '58fe13e34effd3c35a7fc4b8',
+      persona: newPersona.id,
     });
 
     return assertError(NoModel, resultPromise);
+  });
+
+  it('should NoModel error if no found persona', async () => {
+    const {identifier} = await createTestIdentifier();
+
+    const resultPromise = service.setIdentifierPersona({
+      id: identifier.id,
+      organisation: TEST_ORGANISATION,
+      persona: '58fe13e34effd3c33a7fc4b8',
+    });
+
+    return assertError(NoModelWithId, resultPromise);
   });
 
   it('should update existing model', async () => {
@@ -37,7 +51,7 @@ describe('setIdentifierPersona', () => {
   it('should not update identifier outside organisation', async () => {
     const {identifier} = await createTestIdentifier();
 
-    const newPersona = await createTestPersona('Dave 2');
+    const newPersona = await createTestPersona('Dave 2', TEST_ORGANISATION_OUTSIDE_STORE);
 
     const resultPromise = service.setIdentifierPersona({
       id: identifier.id,

--- a/src/tests/updateIdentifier/updateIdentifier.test.ts
+++ b/src/tests/updateIdentifier/updateIdentifier.test.ts
@@ -24,15 +24,9 @@ describe('updateIdentifier', () => {
 
     const {identifier: newIdentifier} = await service.updateIdentifier({
       id: identifier.id,
-      ifi: {
-        key: 'mbox',
-        value: 'test2@test2.com',
-      },
       organisation: TEST_ORGANISATION,
       persona: persona.id,
     });
-
-    assert.equal(newIdentifier.ifi.value, 'test2@test2.com');
 
     const {identifier: actualIdentifier} = await service.getIdentifier({
       id: identifier.id,
@@ -45,10 +39,6 @@ describe('updateIdentifier', () => {
   it('should throw error if no model found', () => {
     const updatePromise = service.updateIdentifier({
       id: '58fe11e24effd3c35a7fc4b8',
-      ifi: {
-        key: 'mbox',
-        value: 'test@test.com',
-      },
       organisation: TEST_ORGANISATION,
     });
 


### PR DESCRIPTION
- check persona exists when updating attributes or identifiers
- prevent creating attributes with empty key
- better utilise $set operator on findOneAndUpdate