### PR TITLE
docs(Status-Badge): Update status badge [CICD-341]

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Persona Service
 
-[![Build Status](https://travis-ci.org/LearningLocker/persona-service.svg?branch=master)](https://travis-ci.org/LearningLocker/persona-service)
+![Build Status](https://github.com/LearningLocker/persona-service/actions/workflows/integration.yml/badge.svg?branch=master)
 [![Renovate badge](https://img.shields.io/badge/Renovate-enabled-brightgreen.svg)](https://renovateapp.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![Join the chat at https://gitter.im/LearningLocker/learninglocker](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/LearningLocker/learninglocker?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
With the migration from CircleCI to GHA, the status badge on the readme should be updated to reflect the change.