### PR TITLE
fix: Add back node 14 support to package.json engines section (LLC-2396)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     }
   },
   "engines": {
-    "node": ">16.0.0",
+    "node": ">=14.0.0",
     "npm": ">8.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Closes LLC-2396.

To allow use of latest persona changes in ll-enterprise while still on node 14.